### PR TITLE
Actually provide stated syslog support

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,6 +32,12 @@ func main() {
 	}
 
 	// begin startup sequence
+	if cfg.Logging.Syslog {
+		if logger, err = simplelog.NewLogger(simplelog.SYSLOG, "sentinel"); err != nil {
+			fmt.Println("failed to create syslog logger:", err)
+			os.Exit(1)
+		}
+	}
 	logger.SetLevel(cfg.Logging.Level)
 
 	var client *Client


### PR DESCRIPTION
Great little tool!

The syslog flag was parsed, but nothing was done with it -- logger was left pointing at `STDOUT` regardless. If enabled, this pull request switches to a new syslog-based logger after configuration has been parsed & validated. it keeps using the `STDOUT` logger until config has been validated so that any config parsing errors are appropriately logged.
