### PR TITLE
When no templates are specified always execute a command

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -91,6 +91,10 @@ type Renderer struct {
 }
 
 func NewRenderer(templates []Template, logger *simplelog.Logger) *Renderer {
+	if len(templates) == 0 {
+		return nil
+	}
+
 	item := &Renderer{
 		templates,
 		logger,


### PR DESCRIPTION
Creates a nil renderer when there are no templates provided. Per the README:

> If no templates are provided to a watcher then the command will always be executed.

This satisfies the check:

https://github.com/BlueDragonX/sentinel/blob/master/watcher.go#L85

```
if watcher.renderer != nil {
```

and seems to behave in the way originally intended.
