### PR TITLE
Move empty templates check to the NewRenderer func

### DIFF
--- a/config_watchers.go
+++ b/config_watchers.go
@@ -79,10 +79,7 @@ func (cfg *WatcherConfig) CreateWatcher(client *Client, logger *simplelog.Logger
 	for _, templateCfg := range cfg.Templates {
 		templates = append(templates, NewTemplate(templateCfg.Src, templateCfg.Dest, logger))
 	}
-	var renderer *Renderer
-	if len(templates) > 0 {
-		renderer = NewRenderer(templates, logger)
-	}
+	renderer := NewRenderer(templates, logger)
 
 	// create command
 	var command []string

--- a/renderer.go
+++ b/renderer.go
@@ -91,7 +91,13 @@ type Renderer struct {
 }
 
 func NewRenderer(templates []Template, logger *simplelog.Logger) *Renderer {
-	item := &Renderer{
+	var item *Renderer
+
+	if len(templates) == 0 {
+		return item
+	}
+
+	item = &Renderer{
 		templates,
 		logger,
 	}


### PR DESCRIPTION
This neatens up the area of responsibility each part of the code handles I think. The CreateWatcher function no-longer needs to know anything about the logic that causes the renderer to be created, it's neatly packaged away in the NewRenderer function, and there is now a guard in the NewRenderer function that will cause it to always be created in the correct way depending on what the templates array looks like without relying in external functions to validate the input for it.

Fixes #6
